### PR TITLE
Install pre-requisite rally plugin

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,6 +61,12 @@
   command: /tmp/install_rally.sh
   when: not rally_bin.stat.exists
 
+- name: Install rally-openstack plugin pre-requisite
+  pip:
+    name: rally-openstack
+    virtualenv: "/home/rally/rally"
+    state: present
+
 - name: Clean up
   yum: name={{item}} state=absent
   with_items:


### PR DESCRIPTION
  * Add a new pip plugin installation whichi is now needed by rally
    install. This hasn't been updated to the intsall.sh script so we
    run this after that task before setting up the rally deployments
    and scenarios

    OpenStack plugins moved to the separate package:
    (see https://pypi.python.org/pypi/rally-openstack).