### PR TITLE
Enable testing and set become: True in the become rally user tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
 env:
   - IMAGE_BUILD_PLATFORM=stable-centos7
   - IMAGE_BUILD_PLATFORM=devel-centos7
+  - IMAGE_BUILD_PLATFORM=pip-ubuntu
 install:
   - npm install -g validate-dockerfile
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ matrix:
   fast_finish: true
 
 env:
-  - IMAGE_BUILD_PLATFORM=stable-centos7
-  - IMAGE_BUILD_PLATFORM=devel-centos7
+  - IMAGE_BUILD_PLATFORM=pip-centos7
   - IMAGE_BUILD_PLATFORM=pip-ubuntu
 install:
   - npm install -g validate-dockerfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,51 @@
+language: python
+
+sudo: required
+dist: trusty
+group: edge
+
+services:
+  - docker
+
+matrix:
+  fast_finish: true
+
+env:
+  - IMAGE_BUILD_PLATFORM=stable-centos7
+  - IMAGE_BUILD_PLATFORM=devel-centos7
+install:
+  - npm install -g validate-dockerfile
+
+before_script:
+  # TESTDIR = Where the stable-centos/Dockerfile is located
+  - export TESTDIR=tests
+  # ROLETOTEST = The name of this repo
+  - export ROLETOTEST=$(basename $(pwd))
+  - export COMMIT=${TRAVIS_COMMIT::8}
+  # The tag we assign the docker image we build with the Dockerfile
+  - export REPO=csc/ansible
+  # https://www.npmjs.com/package/validate-dockerfile - validate the Dockerfile
+  - docklint ${TESTDIR}/${IMAGE_BUILD_PLATFORM}/Dockerfile
+  # Build the image
+  - docker build -t ${REPO}:${IMAGE_BUILD_PLATFORM} ${TESTDIR}/${IMAGE_BUILD_PLATFORM}/
+  # Launch the container
+  - docker run --privileged -d -ti -e "container=docker"  -v `pwd`:/$ROLETOTEST -v /sys/fs/cgroup:/sys/fs/cgroup  ${REPO}:${IMAGE_BUILD_PLATFORM}  /usr/sbin/init
+  - DOCKER_CONTAINER_ID=$(docker ps | grep ${IMAGE_BUILD_PLATFORM} | awk '{print $1}')
+  - docker logs $DOCKER_CONTAINER_ID
+script:
+  # Testing of this ansible-role:
+  - docker exec -ti $DOCKER_CONTAINER_ID /bin/sh -c "/$ROLETOTEST/tests/test-in-docker-image.sh"
+after_script:
+  - >
+    docker exec -ti $DOCKER_CONTAINER_ID /bin/sh -c 'echo -ne "------\nEND ANSIBLE TESTS\n------\nSystemD Units:\n------\n";
+       systemctl --no-pager --all --full status ;
+       echo -ne "------\nJournalD Logs:\n------\n" ;
+       sudo journalctl --catalog --all --full --no-pager'
+  - docker exec -ti $DOCKER_CONTAINER_ID /bin/sh -c 'tree /ansible*'
+  - docker exec -ti $DOCKER_CONTAINER_ID /bin/sh -c 'tree /etc'
+  - docker ps -a
+  - docker stop $DOCKER_CONTAINER_ID
+  - docker rm -v $DOCKER_CONTAINER_ID
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/CSCfi/ansible-role-rally.svg?branch=master)](https://travis-ci.org/CSCfi/ansible-role-rally)
+
 # ansible-role-rally
 
 This role does a basic installation of openstack-rally for the "rally" user. Currenly it has minor configuration capabilities for the rally tempest options.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,7 +71,7 @@
 
 - name: Create Rally directories
   file:
-    path: "{{ item.path }}"
+    path: "{{item.path}}"
     state: directory
     owner: rally
     group: rally
@@ -105,7 +105,7 @@
     virtualenv: "/home/rally/rally"
     state: present
 
-- name: Clean up
+- name: Clean up devel packages on EL if rally has been successfully installed
   package:
     name: "{{item}}"
     state: absent
@@ -116,7 +116,7 @@
     - "libxslt-devel"
     - "gcc"
   when:
-    - (ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux')
+    - ansible_os_family == "RedHat"
     - reg_install_rally is success
 
 - name: Rally configure swift operator role
@@ -125,7 +125,7 @@
   lineinfile: 
     path: "/home/rally/rally/etc/rally/rally.conf"
     regexp: "swift_operator_role"
-    line: "swift_operator_role = {{ rally_tempest_swift_operator_role }}"
+    line: "swift_operator_role = {{rally_tempest_swift_operator_role}}"
   when: rally_tempest_swift_operator_role is defined
 
 - name: Rally configure swift reseller admin role
@@ -134,5 +134,5 @@
   lineinfile: 
     path: "/home/rally/rally/etc/rally/rally.conf"
     regexp: "swift_reseller_admin_role"
-    line: "swift_reseller_admin_role = {{ rally_tempest_swift_reseller_admin_role }}"
+    line: "swift_reseller_admin_role = {{rally_tempest_swift_reseller_admin_role}}"
   when: swift_reseller_admin_role is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,8 +31,8 @@
   when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux' and not rally_bin.stat.exists
 
 - name: Install dependencies Ubuntu
-  apt: 
-    name: "{{item}}" 
+  apt:
+    name: "{{item}}"
     state: installed
   with_items:
     - "python-pip"
@@ -52,9 +52,9 @@
   when: ansible_distribution == 'Ubuntu' and not rally_bin.stat.exists
 
 - name: Create group for Rally
-  group: 
-    name: rally 
-    state: present 
+  group:
+    name: rally
+    state: present
     system: yes
   when: not rally_bin.stat.exists
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,11 @@
     path: /home/rally/rally/bin/rally
   register: rally_bin
 
+- name: print rally_bin when verbosity is 1
+  debug:
+    var: rally_bin
+    verbosity: 1
+
 - name: Install dependencies Centos
   yum:
     name: "{{item}}"
@@ -77,6 +82,8 @@
   when: not rally_bin.stat.exists
 
 - name: Get Rally installation script
+  become: True
+  become_user: rally
   get_url:
     url: https://raw.githubusercontent.com/openstack/rally/master/install_rally.sh
     mode: 0774
@@ -86,6 +93,7 @@
   when: not rally_bin.stat.exists
 
 - name: Install rally
+  become: True
   become_user: rally
   command: /tmp/install_rally.sh
   register: reg_install_rally
@@ -112,6 +120,7 @@
     - reg_install_rally is success
 
 - name: Rally configure swift operator role
+  become: True
   become_user: rally
   lineinfile: 
     path: "/home/rally/rally/etc/rally/rally.conf"
@@ -120,6 +129,7 @@
   when: rally_tempest_swift_operator_role is defined
 
 - name: Rally configure swift reseller admin role
+  become: True
   become_user: rally
   lineinfile: 
     path: "/home/rally/rally/etc/rally/rally.conf"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -76,7 +76,7 @@
 - name: Get Rally installation script
   get_url:
     url: https://raw.githubusercontent.com/openstack/rally/master/install_rally.sh
-    mode: 0776
+    mode: 0774
     owner: rally
     group: rally
     dest: /tmp
@@ -103,9 +103,13 @@
     - "libxml2-devel"
     - "libxslt-devel"
     - "gcc"
-  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux' and not rally_bin.stat.exists
+  become_user: root
+  when:
+    - (ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux')
+    - not rally_bin.stat.exists
 
 - name: Rally configure swift operator role
+  become_user: rally
   lineinfile: 
     path: "/home/rally/rally/etc/rally/rally.conf"
     regexp: "swift_operator_role"
@@ -113,6 +117,7 @@
   when: rally_tempest_swift_operator_role is defined
 
 - name: Rally configure swift reseller admin role
+  become_user: rally
   lineinfile: 
     path: "/home/rally/rally/etc/rally/rally.conf"
     regexp: "swift_reseller_admin_role"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,59 +1,84 @@
 ---
 
 - name: Check if Rally is installed - check if we have rally/bin, pass installation if it exists
-  stat: path=/home/rally/rally/bin/rally
+  stat:
+    path: /home/rally/rally/bin/rally
   register: rally_bin
 
 - name: Install dependencies Centos
-  yum: name={{item}} state=installed
+  yum:
+    name: "{{item}}"
+    state: installed
   with_items:
-  - "python2-pip"
-  - "wget"
-  - "sqlite"
-  - "python-devel"
-  - "openssl-devel"
-  - "git"
-  - "libffi-devel"
-  - "gcc"
-  - "libxml2-devel"
-  - "libxslt-devel"
+    - "python2-pip"
+    - "wget"
+    - "sqlite"
+    - "python-devel"
+    - "openssl-devel"
+    - "git"
+    - "libffi-devel"
+    - "gcc"
+    - "libxml2-devel"
+    - "libxslt-devel"
   when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux' and not rally_bin.stat.exists
 
 - name: Install dependencies Ubuntu
-  apt: name={{item}} state=installed
+  apt: 
+    name: "{{item}}" 
+    state: installed
   with_items:
-  - "python-pip"
-  - "python-setuptools"
-  - "wget"
-  - "sqlite"
-  - "python-dev"
-  - "libpython-dev"
-  - "libssl-dev"
-  - "git"
-  - "libffi-dev"
-  - "build-essential"
-  - "libxml2-dev"
-  - "libxslt-dev"
-  - "libpq-dev"
+    - "python-pip"
+    - "python-setuptools"
+    - "wget"
+    - "sqlite"
+    - "python-dev"
+    - "libpython-dev"
+    - "libssl-dev"
+    - "git"
+    - "libffi-dev"
+    - "build-essential"
+    - "libxml2-dev"
+    - "libxslt-dev"
+    - "libpq-dev"
   when: ansible_distribution == 'Ubuntu' and not rally_bin.stat.exists
 
 - name: Create group for Rally
-  group: name=rally state=present system=yes
+  group: 
+    name: rally 
+    state: present 
+    system: yes
   when: not rally_bin.stat.exists
 
 - name: Create user for Rally
-  user: name=rally groups=rally shell=/bin/bash state=present system=yes createhome=yes home=/home/rally
+  user:
+    name: rally
+    groups: rally
+    shell: /bin/bash
+    state: present
+    system: yes
+    createhome: yes
+    home: /home/rally
   when: not rally_bin.stat.exists
 
 - name: Create Rally directories
-  file: path={{ item.path }} state=directory owner=rally group=rally mode=0750
+  file:
+    path: "{{ item.path }}"
+    state: directory
+    owner: rally
+    group: rally
+    mode: 0750
   with_items:
     - path: "/etc/rally"
     - path: "/home/rally"
   when: not rally_bin.stat.exists
 
 - name: Get Rally installation script
-  get_url: url=https://raw.githubusercontent.com/openstack/rally/master/install_rally.sh mode=0776 owner=rally group=rally dest=/tmp
+  get_url:
+    url: https://raw.githubusercontent.com/openstack/rally/master/install_rally.sh
+    mode: 0776
+    owner: rally
+    group: rally
+    dest: /tmp
   when: not rally_bin.stat.exists
 
 - name: Install rally
@@ -68,13 +93,15 @@
     state: present
 
 - name: Clean up
-  yum: name={{item}} state=absent
+  yum:
+    name: "{{item}}"
+    state: absent
   with_items:
-  - "python-devel"
-  - "openssl-devel"
-  - "libxml2-devel"
-  - "libxslt-devel"
-  - "gcc"
+    - "python-devel"
+    - "openssl-devel"
+    - "libxml2-devel"
+    - "libxslt-devel"
+    - "gcc"
   when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux' and not rally_bin.stat.exists
 
 - name: Rally configure swift operator role

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,9 @@
     - "gcc"
     - "libxml2-devel"
     - "libxslt-devel"
+    - "gmp-devel"
+    - "postgresql-devel"
+    - "redhat-rpm-config"
   when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux' and not rally_bin.stat.exists
 
 - name: Install dependencies Ubuntu
@@ -46,9 +49,6 @@
     - "libxslt-dev"
     - "libpq-dev"
     - "iputils-ping"
-    - "gmp-devel"
-    - "postgresql-devel"
-    - "redhat-rpm-config"
   when: ansible_distribution == 'Ubuntu' and not rally_bin.stat.exists
 
 - name: Create group for Rally

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,6 +40,7 @@
     - "libxml2-dev"
     - "libxslt-dev"
     - "libpq-dev"
+    - "iputils-ping"
   when: ansible_distribution == 'Ubuntu' and not rally_bin.stat.exists
 
 - name: Create group for Rally
@@ -93,7 +94,7 @@
     state: present
 
 - name: Clean up
-  yum:
+  package:
     name: "{{item}}"
     state: absent
   with_items:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -135,4 +135,4 @@
     path: "/home/rally/rally/etc/rally/rally.conf"
     regexp: "swift_reseller_admin_role"
     line: "swift_reseller_admin_role = {{rally_tempest_swift_reseller_admin_role}}"
-  when: swift_reseller_admin_role is defined
+  when: rally_tempest_swift_reseller_admin_role is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,6 +41,9 @@
     - "libxslt-dev"
     - "libpq-dev"
     - "iputils-ping"
+    - "gmp-devel"
+    - "postgresql-devel"
+    - "redhat-rpm-config"
   when: ansible_distribution == 'Ubuntu' and not rally_bin.stat.exists
 
 - name: Create group for Rally
@@ -85,6 +88,7 @@
 - name: Install rally
   become_user: rally
   command: /tmp/install_rally.sh
+  register: reg_install_rally
   when: not rally_bin.stat.exists
 
 - name: Install rally-openstack plugin pre-requisite
@@ -103,10 +107,9 @@
     - "libxml2-devel"
     - "libxslt-devel"
     - "gcc"
-  become_user: root
   when:
     - (ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux')
-    - not rally_bin.stat.exists
+    - reg_install_rally is success
 
 - name: Rally configure swift operator role
   become_user: rally

--- a/tests/devel-centos7/Dockerfile
+++ b/tests/devel-centos7/Dockerfile
@@ -1,0 +1,41 @@
+# Latest version of centos
+FROM centos:centos7
+MAINTAINER James Cuzella <james.cuzella@lyraphase.com>
+RUN yum clean all && \
+    yum -y install epel-release && \
+    yum makecache all && \
+    yum -y groups mark convert && \
+    yum -y groups mark install "Development Tools" && \
+    yum -y groups mark convert "Development Tools" && \
+    yum -y groupinstall "Development Tools" && \
+    yum -y install libffi-devel openssl-devel && \
+    yum -y install python-devel MySQL-python sshpass && \
+    yum -y install acl sudo && \
+    sed -i -e 's/^Defaults.*requiretty/Defaults    !requiretty/' -e 's/^%wheel.*ALL$/%wheel    ALL=(ALL)    NOPASSWD: ALL/' /etc/sudoers && \
+    yum -y install PyYAML python-jinja2 python-httplib2 python-keyczar python-paramiko python-setuptools git python-pip && \
+    pip install --upgrade pip && \
+    pip install requests[security] && \
+    pip install pyrax pysphere boto boto3 passlib dnspython && \
+    sh -c 'yum -y remove libffi-devel || yum -y --setopt=tsflags=noscripts remove libffi-devel' && \
+    yum -y remove $(rpm -qa "*-devel") && \
+    yum -y groupremove "Development tools" && \
+    yum -y autoremove && \
+    yum -y install bzip2 crontabs file findutils gem git gzip hg hostname procps-ng svn sudo tar tree which unzip xz zip && \
+    yum clean all && rm -rf /var/cache/yum
+
+RUN mkdir /etc/ansible/
+RUN echo -e '[local]\nlocalhost\n' > /etc/ansible/hosts
+RUN mkdir /opt/ansible/
+RUN git clone http://github.com/ansible/ansible.git /opt/ansible/ansible
+WORKDIR /opt/ansible/ansible
+RUN git submodule update --init
+ENV PATH /opt/ansible/ansible/bin:/bin:/usr/bin:/sbin:/usr/sbin
+ENV PYTHONPATH /opt/ansible/ansible/lib
+ENV ANSIBLE_LIBRARY /opt/ansible/ansible/library
+# Workaround bug in pip / pylockfile: http://pad.lv/1472101
+# If HOME is a volume mount, causes infinite loop in pip trying to write lock
+ENV XDG_CACHE_HOME /tmp/
+RUN source /opt/ansible/ansible/hacking/env-setup
+
+
+CMD /bin/bash

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,0 +1,4 @@
+localhost
+
+[login]
+localhost

--- a/tests/pip-centos7/Dockerfile
+++ b/tests/pip-centos7/Dockerfile
@@ -17,5 +17,6 @@ RUN yum clean all && \
 RUN mkdir /etc/ansible/
 RUN echo -e '[local]\nlocalhost' > /etc/ansible/hosts
 RUN pip install ansible
+RUN ansible --version
 
 CMD ["/bin/bash"]

--- a/tests/pip-ubuntu/Dockerfile
+++ b/tests/pip-ubuntu/Dockerfile
@@ -1,0 +1,49 @@
+FROM ubuntu:16.04
+# You can change the FROM Instruction to your existing images if you like and build it with same tag
+ENV container docker
+ENV LC_ALL C
+ENV DEBIAN_FRONTEND noninteractive
+RUN echo 'APT::Install-Recommends "0"; \n\
+APT::Get::Assume-Yes "true"; \n\
+APT::Get::force-yes "true"; \n\
+APT::Install-Suggests "0";' > /etc/apt/apt.conf.d/01buildconfig
+RUN mkdir -p  /etc/apt/sources.d/
+RUN echo "deb mirror://mirrors.ubuntu.com/mirrors.txt xenial main restricted universe multiverse \n\
+deb mirror://mirrors.ubuntu.com/mirrors.txt xenial-updates main restricted universe multiverse \n\
+deb mirror://mirrors.ubuntu.com/mirrors.txt xenial-backports main restricted universe multiverse \n\
+deb mirror://mirrors.ubuntu.com/mirrors.txt xenial-security main restricted universe multiverse" > /etc/apt/sources.d/ubuntu-mirrors.list
+RUN apt-get update && apt-get install systemd sudo && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN cd /lib/systemd/system/sysinit.target.wants/; ls | grep -v systemd-tmpfiles-setup | xargs rm -f $1 \
+rm -f /lib/systemd/system/multi-user.target.wants/*;\
+rm -f /etc/systemd/system/*.wants/*;\
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*;\
+rm -f /lib/systemd/system/anaconda.target.wants/*; \
+rm -f /lib/systemd/system/plymouth*; \
+rm -f /lib/systemd/system/systemd-update-utmp*;
+RUN systemctl set-default multi-user.target
+
+#
+RUN \
+  sed -i -e 's/^Defaults.*requiretty/Defaults    !requiretty/' -e 's/^%wheel.*ALL$/%wheel    ALL=(ALL)    NOPASSWD: ALL/' /etc/sudoers && \
+  sed -i 's/# \(.*multiverse$\)/\1/g' /etc/apt/sources.list && \
+  apt-get update && \
+  apt-get -y upgrade && \
+  apt-get install -y build-essential && \
+  apt-get install -y software-properties-common && \
+  apt-get install -y byobu curl git htop man unzip vim wget python-pip tree && \
+  apt-get install -y libyaml-dev python-dev python-jinja2 python-httplib2 python-keyczar python-paramiko python-setuptools python3-setuptools && \
+  apt-get install -y libffi-dev libssl-dev && \
+  pip install setuptools pyrax pysphere boto passlib dnspython
+
+RUN mkdir /etc/ansible/
+RUN echo -e '[local]\nlocalhost' > /etc/ansible/hosts
+RUN pip install ansible
+
+ENV init /lib/systemd/systemd
+VOLUME [ "/sys/fs/cgroup" ]
+# docker run -it --privileged=true -v /sys/fs/cgroup:/sys/fs/cgroup:ro 444c127c995b /lib/systemd/systemd systemd.unit=emergency.service
+ENTRYPOINT ["/lib/systemd/systemd"]
+CMD ["/bin/bash"]

--- a/tests/stable-centos7/Dockerfile
+++ b/tests/stable-centos7/Dockerfile
@@ -1,0 +1,21 @@
+# Latest version of centos
+FROM centos:centos7
+MAINTAINER James Cuzella <james.cuzella@lyraphase.com>
+RUN yum clean all && \
+    yum -y install epel-release && \
+    yum -y groupinstall "Development tools" && \
+    yum -y install python-devel MySQL-python sshpass && \
+    yum -y install acl sudo && \
+    sed -i -e 's/^Defaults.*requiretty/Defaults    !requiretty/' -e 's/^%wheel.*ALL$/%wheel    ALL=(ALL)    NOPASSWD: ALL/' /etc/sudoers && \
+    yum -y install PyYAML python-jinja2 python-httplib2 python-keyczar python-paramiko python-setuptools git python-pip \
+    pip install pyrax pysphere boto passlib dnspython && \
+    yum -y remove $(rpm -qa "*-devel") && \
+    yum -y groupremove "Development tools" && \
+    yum -y autoremove && \
+    yum -y install bzip2 crontabs file findutils gem git gzip hg hostname procps-ng svn sudo tar tree which unzip xz zip
+
+RUN mkdir /etc/ansible/
+RUN echo -e '[local]\nlocalhost' > /etc/ansible/hosts
+RUN pip install ansible
+
+CMD ["/bin/bash"]

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+
+SOURCE="${BASH_SOURCE[0]}"
+RDIR="$( dirname "$SOURCE" )"
+SUDO=`which sudo 2> /dev/null`
+SUDO_OPTION=""
+#SUDO_OPTION="--sudo"
+OS_TYPE=${1:-}
+OS_VERSION=${2:-}
+ANSIBLE_VERSION=${3:-}
+
+ANSIBLE_VAR=""
+ANSIBLE_INVENTORY="tests/inventory"
+ANSIBLE_PLAYBOOk="tests/test.yml"
+#ANSIBLE_LOG_LEVEL=""
+ANSIBLE_LOG_LEVEL="-v"
+APACHE_CTL="apache2ctl"
+
+# if there wasn't sudo then ansible couldn't use it
+if [ "x$SUDO" == "x" ];then
+    SUDO_OPTION=""
+fi
+
+if [ "${OS_TYPE}" == "stable-centos7-puppet5" ];then
+  echo "TEST: set tests/test5.yml as playbook"
+  ANSIBLE_PLAYBOOk="tests/test5.yml"
+fi
+
+ANSIBLE_EXTRA_VARS=""
+if [ "${ANSIBLE_VAR}x" == "x" ];then
+    ANSIBLE_EXTRA_VARS=" -e \"${ANSIBLE_VAR}\" "
+fi
+
+
+cd $RDIR/..
+printf "[defaults]\nroles_path = ../:roles\ncallback_whitelist = profile_tasks" > ansible.cfg
+printf "" > ssh.config
+
+function show_version() {
+
+echo "TEST: show versions"
+ansible --version
+id
+systemctl --no-pager
+proc1comm=$(cat /proc/1/comm)
+echo "TEST: proc1s comm is $proc1comm"
+
+}
+
+function install_ansible_devel() {
+
+# http://docs.ansible.com/ansible/intro_installation.html#latest-release-via-yum
+
+echo "TEST: building ansible"
+
+yum -y install PyYAML python-paramiko python-jinja2 python-httplib2 rpm-build make python2-devel asciidoc patch wget 2>&1 >/dev/null || (echo "Could not install ansible yum dependencies" && exit 2 )
+rm -Rf ansible
+git clone https://github.com/ansible/ansible --recursive ||(echo "Could not clone ansible from Github" && exit 2 )
+cd ansible
+# checking out this commit because some errors after 2015-11-05
+#git checkout 07d0d2720c73816e1206882db7bc856087eb5c3f
+# because systemctl and systemd
+git checkout 589971fe7ef78ea8bb41fb9ae6cd19cb8e277371
+make rpm 2>&1 >/dev/null
+rpm -Uvh ./rpm-build/ansible-*.noarch.rpm ||(echo "Could not install built ansible devel rpms" && exit 2 )
+cd ..
+rm -Rf ansible
+
+}
+
+function install_os_deps() {
+echo "TEST: installing os deps"
+
+yum -y install epel-release sudo tree git which file less||(echo "Could not install some os deps" && exit 2 )
+
+}
+
+function tree_list() {
+
+tree
+
+}
+function test_ansible_setup(){
+    echo "TEST: ansible -m setup -i ${ANSIBLE_INVENTORY} --connection=local localhost"
+
+    ansible -m setup -i ${ANSIBLE_INVENTORY} --connection=local localhost
+
+}
+
+
+function test_install_requirements(){
+    echo "TEST: ansible-galaxy install -r requirements.yml --force"
+
+    ansible-galaxy install -r requirements.yml --force ||(echo "requirements install failed" && exit 2 )
+
+}
+
+function test_playbook_syntax(){
+    echo "TEST: ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} --syntax-check"
+
+    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} --syntax-check ||(echo "ansible playbook syntax check was failed" && exit 2 )
+}
+
+function test_playbook_check(){
+    echo "TEST: ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} --check"
+
+    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} --check ||(echo "playbook check failed" && exit 2 )
+
+
+}
+
+function test_playbook(){
+    echo "TEST: ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS}"
+
+    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} ||(echo "first ansible run failed" && exit 2 )
+
+
+    echo "TEST: idempotence test! Same as previous but now grep for changed=0.*failed=0"
+    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} || grep -q 'changed=0.*failed=0' && (echo 'Idempotence test: pass' ) || (echo 'Idempotence test: fail' && exit 1)
+}
+function extra_tests(){
+
+    echo "TEST: ls /etc/puppet/*"
+    ls /etc/puppet/
+
+}
+
+
+set -e
+function main(){
+#    install_os_deps
+#    install_ansible_devel
+#    show_version
+#    tree_list
+#    test_install_requirements
+    test_ansible_setup
+    test_playbook_syntax
+    test_playbook
+    test_playbook_check
+#    extra_tests
+
+}
+
+################ run #########################
+main

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -13,7 +13,7 @@ ANSIBLE_VAR=""
 ANSIBLE_INVENTORY="tests/inventory"
 ANSIBLE_PLAYBOOk="tests/test.yml"
 #ANSIBLE_LOG_LEVEL=""
-ANSIBLE_LOG_LEVEL="-v"
+ANSIBLE_LOG_LEVEL="-vvv"
 APACHE_CTL="apache2ctl"
 
 # if there wasn't sudo then ansible couldn't use it

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -120,8 +120,8 @@ function test_playbook(){
 }
 function extra_tests(){
 
-    echo "TEST: ls /etc/puppet/*"
-    ls /etc/puppet/
+    echo "TEST: cat /home/rally/rally/etc/rally/rally.conf"
+    cat /home/rally/rally/etc/rally/rally.conf
 
 }
 
@@ -137,7 +137,7 @@ function main(){
     test_playbook_syntax
     test_playbook
     test_playbook_check
-#    extra_tests
+    extra_tests
 
 }
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -3,6 +3,9 @@
  - name: configure rally
    hosts: login
    connection: local
+   vars:
+     - rally_tempest_swift_operator_role: Member
+     - rally_tempest_swift_reseller_admin_role: ResellerAdmin
    roles:
      - ansible-role-rally
 ...

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,7 +1,8 @@
 ---
 
- - hosts: localhost
-   remote_user: root
+ - name: configure rally
+   hosts: login
+   connection: local
    roles:
      - ansible-role-rally
 ...

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,7 @@
+---
+
+ - hosts: localhost
+   remote_user: root
+   roles:
+     - ansible-role-rally
+...

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -4,8 +4,8 @@
    hosts: login
    connection: local
    vars:
-     - rally_tempest_swift_operator_role: Member
-     - rally_tempest_swift_reseller_admin_role: ResellerAdmin
+     - rally_tempest_swift_operator_role: SomethingOtherThanMember
+     - rally_tempest_swift_reseller_admin_role: SomethingOtherThanResellerAdmin
    roles:
      - ansible-role-rally
 ...


### PR DESCRIPTION
 - enables testing of this role against both Ubuntu and CentOS 7
 - normalize yaml format
 - install some more dependencies that the install script wanted
 - to make the cleanup task also work with ansible 2.5 and CentOS 7 and connection=local we need to set "become: True" on the tasks where we do become_user: rally. 
 - only cleanup if the install script succeeded
 - align conditional for setting swift reseller role lineinefile with the one in the ansible defaults/

Error message seen without the become: True was:

<pre>
TASK [ansible-role-rally : Clean up]
*******************************************
Friday 13 April 2018  11:31:23 +0000 (0:02:33.782)       0:02:50.291
**********
An exception occurred during task execution. To see the full traceback,
use -vvv. The error was: AttributeError: 'Connection' object has no
attribute 'supports_persistence'
fatal: [localhost]: FAILED! => {"msg": "Unexpected failure during module
execution.", "stdout": ""}
</pre>