### PR TITLE
Remove cleanup packages task for CentOS

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -105,20 +105,6 @@
     virtualenv: "/home/rally/rally"
     state: present
 
-- name: Clean up devel packages on EL if rally has been successfully installed
-  package:
-    name: "{{item}}"
-    state: absent
-  with_items:
-    - "python-devel"
-    - "openssl-devel"
-    - "libxml2-devel"
-    - "libxslt-devel"
-    - "gcc"
-  when:
-    - ansible_os_family == "RedHat"
-    - reg_install_rally is success
-
 - name: Rally configure swift operator role
   become: True
   become_user: rally


### PR DESCRIPTION
  * Remove this task due to the failure of tempest verifiers setup
    using the ansible-role-rally-scenarios on CentOS. This removes gcc
    which is needed by the pip virtual env setup when deploying the
    verifiers. This error is shown when the task fails in the
    rally-scenarios role.

    `"  error: command 'gcc' failed with exit status 1"`