### PR TITLE
become rally user when installing rally-openstack

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -100,6 +100,8 @@
   when: not rally_bin.stat.exists
 
 - name: Install rally-openstack plugin pre-requisite
+  become: True
+  become_user: rally
   pip:
     name: rally-openstack
     virtualenv: "/home/rally/rally"


### PR DESCRIPTION
Without it then stuff inside /home/rally/rally will be owned by user
root