### PR TITLE
The swift_*_role settings needs to be under [openstack] section

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -118,17 +118,19 @@
 - name: Rally configure swift operator role
   become: True
   become_user: rally
-  lineinfile: 
+  ini_file:
     path: "/home/rally/rally/etc/rally/rally.conf"
-    regexp: "swift_operator_role"
-    line: "swift_operator_role = {{rally_tempest_swift_operator_role}}"
+    section: openstack
+    option: swift_operator_role
+    value: "{{rally_tempest_swift_operator_role}}"
   when: rally_tempest_swift_operator_role is defined
 
 - name: Rally configure swift reseller admin role
   become: True
   become_user: rally
-  lineinfile: 
+  ini_file: 
     path: "/home/rally/rally/etc/rally/rally.conf"
-    regexp: "swift_reseller_admin_role"
-    line: "swift_reseller_admin_role = {{rally_tempest_swift_reseller_admin_role}}"
+    section: openstack
+    option: "swift_reseller_admin_role"
+    value: "{{rally_tempest_swift_reseller_admin_role}}"
   when: rally_tempest_swift_reseller_admin_role is defined


### PR DESCRIPTION
If for some reason rally.conf does not have an [openstack] section,
then the settings in these tasks will end up under [database] section
and rally would in our case not be able to run any tempest verifiers
anymore (giving a nice 409 conflict error when trying to create the
Member role).

Let's use ini_file because this file is actually an ini file :)

 - #CCCP-1837