### PR TITLE
WIP - Set openstack client timeout

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,4 +8,6 @@
 
 rally_install_version: "master"
 
-rally_openstack_client_http_timeout: "180"
+# Variables for rally.conf with syntax rally_[section]_[variable]
+
+rally_default_openstack_client_http_timeout: "180"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,4 @@
 
 rally_install_version: "master"
 
+rally_openstack_client_http_timeout: "180"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -151,4 +151,4 @@
     path: "/home/rally/rally/etc/rally/rally.conf"
     section: DEFAULT
     option: "openstack_client_http_timeout"
-    value: "{{ rally_openstack_client_http_timeout }}"
+    value: "{{ rally_default_openstack_client_http_timeout }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -151,4 +151,4 @@
     path: "/home/rally/rally/etc/rally/rally.conf"
     section: DEFAULT
     option: "openstack_client_http_timeout"
-    value: "180"
+    value: "{{ rally_openstack_client_http_timeout }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -143,3 +143,12 @@
     option: "swift_reseller_admin_role"
     value: "{{rally_tempest_swift_reseller_admin_role}}"
   when: rally_tempest_swift_reseller_admin_role is defined
+
+- name: Rally set openstack client timeout
+  become: True
+  become_user: rally
+  ini_file:
+    path: "/home/rally/rally/etc/rally/rally.conf"
+    section: DEFAULT
+    option: "openstack_client_http_timeout"
+    value: "180"


### PR DESCRIPTION
Set a default timeout of 180 seconds for all openstack clients.
This should affect both nova and cinder and thus possibly mitigate
some test failures currently hitting a 60 sec timeout.