### PR TITLE
Allow specifying more options to install_rally.sh

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,9 @@
 # rally_tempest_swift_operator_role: Member
 # rally_tempest_swift_reseller_admin_role: ResellerAdmin
 
+# Arguments to install_rally.sh can be found on:
+#  https://rally.readthedocs.io/en/latest/install_and_upgrade/install.html
 rally_install_version: "master"
+rally_install_args: "--branch {{ rally_install_version }}"
 #rally_openstack_install_version: "1.3.0"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -95,7 +95,7 @@
 - name: Install rally
   become: True
   become_user: rally
-  command: /tmp/install_rally.sh --branch "{{rally_install_version}}"
+  command: "/tmp/install_rally.sh {{ rally_install_args }}"
   register: reg_install_rally
   when: not rally_bin.stat.exists
 


### PR DESCRIPTION
 So that we can for example set --dbtype "mysql" to store the rally data in an
SQL database instead of the default sqlite

 - #CCCP-2767