### PR TITLE
Give rally a larger open file limit

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -152,3 +152,13 @@
     option: "swift_reseller_admin_role"
     value: "{{ rally_tempest_swift_reseller_admin_role }}"
   when: rally_tempest_swift_reseller_admin_role is defined
+
+- name: Give rally a larger open file limit to support running bigger concurrent tasks
+  pam_limits:
+    domain: rally
+    limit_type: "{{ item }}"
+    limit_item: nofile
+    value: 500000
+  with_items:
+    - hard
+    - soft


### PR DESCRIPTION
To help getting 100s of parallel object storage tests running without "Too many open files" errors.