### PR TITLE
Configure logrotate for rally tempest.log

### DIFF
--- a/files/rallyverifiers-logrotate
+++ b/files/rallyverifiers-logrotate
@@ -1,0 +1,7 @@
+/home/rally/.rally/verification/*/*/tempest.log {
+    rotate 5
+    compress
+    missingok
+    weekly
+    create 0644 rally users
+}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -164,3 +164,9 @@
   with_items:
     - hard
     - soft
+
+- name: Add logrotate.d config for tempest.log
+  become: true
+  tags: logrotate
+  copy:
+     src=rallyverifiers-logrotate dest=/etc/logrotate.d/rallyverifiers-logrotate


### PR DESCRIPTION
This configures logrotate.d to rotate all tempest.log files weekly(typically sunday) They are compressed and keeps 5 old which should be fine for the storage we have.