### PR TITLE
Lock rally to a python2.7 compatible version.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@
 #  https://rally.readthedocs.io/en/latest/install_and_upgrade/install.html
 rally_install_version: "master"
 rally_install_args: "--branch {{ rally_install_version }}"
+rally_install_upstream: "openstack"
 #rally_openstack_install_version: "1.3.0"
 
 rally_verify_purger_cron_enabled: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,7 +58,7 @@
   become: True
   become_user: rally
   get_url:
-    url: https://raw.githubusercontent.com/openstack/rally/master/install_rally.sh
+    url: https://raw.githubusercontent.com/{{ rally_install_upstream }}/rally/{{ rally_install_version }}/install_rally.sh
     mode: 0774
     owner: rally
     group: rally

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,4 +1,8 @@
 localhost
 
+[all:vars]
+rally_install_version=Python27
+rally_install_upstream=cscfi
+
 [login]
 localhost

--- a/tests/pip-centos7/Dockerfile
+++ b/tests/pip-centos7/Dockerfile
@@ -16,6 +16,7 @@ RUN yum clean all && \
 
 RUN mkdir /etc/ansible/
 RUN echo -e '[local]\nlocalhost' > /etc/ansible/hosts
+RUN pip install cryptography==2.8 bcrypt==3.1.7 PyNaCl==1.3.0
 RUN pip install ansible==2.5.5
 RUN ansible --version
 

--- a/tests/pip-ubuntu/Dockerfile
+++ b/tests/pip-ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 # You can change the FROM Instruction to your existing images if you like and build it with same tag
 ENV container docker
 ENV LC_ALL C
@@ -35,8 +35,10 @@ RUN \
   apt-get install -y software-properties-common && \
   apt-get install -y byobu curl git htop man unzip vim wget python-pip tree && \
   apt-get install -y libyaml-dev python-dev python-jinja2 python-httplib2 python-keyczar python-paramiko python-setuptools python3-setuptools && \
-  apt-get install -y libffi-dev libssl-dev && \
-  pip install setuptools pyrax pysphere boto passlib dnspython
+  apt-get install -y libffi-dev libssl-dev
+
+RUN pip install cryptography==2.8 bcrypt==3.1.7 PyNaCl==1.3.0 wheel
+RUN pip install setuptools pysphere boto passlib dnspython
 
 RUN mkdir /etc/ansible/
 RUN echo -e '[local]\nlocalhost' > /etc/ansible/hosts


### PR DESCRIPTION
Fix some pip modules to python2 compatible versions

Upgrade ubuntu to 18.04 and fix some packages that were causing conflicts